### PR TITLE
String to Boolean type converting. Unexpected XML output.

### DIFF
--- a/payture/Payture.php
+++ b/payture/Payture.php
@@ -68,8 +68,6 @@ abstract class Payture
      */
     private static function _convertResponse($XMLString)
     {
-        echo $XMLString;
-
         $xml = new SimpleXMLIterator($XMLString);
 
         $resultObject = self::_XMLNodeToArray($xml);
@@ -90,7 +88,8 @@ abstract class Payture
         $result = array();
         foreach($XMLNode->attributes() as $k => $v){
             $val = (string)$v;
-            if($val == "True" || $val == "False") $val = (bool)$val;
+            if ($val === "True") $val = true;
+            if ($val === "False") $val = false;
             $result[$k] = $val;
         }
         foreach($XMLNode->children() as $chK =>  $chNode){


### PR DESCRIPTION
1. Right now in both cases when XML response contains Success="True" and  Success="False" object representation is always true.
2. Unexpected XML output when XML response converting to the response object.