### PR TITLE
Prevent an error if SessionId not in object

### DIFF
--- a/payture/PaytureInPay.php
+++ b/payture/PaytureInPay.php
@@ -37,7 +37,7 @@ class PaytureInPay extends Payture
             array( "Key" => PaytureConfiguration::getMerchantKey(), "Data" => self::stringify( $data ) )
         );
 
-        if ($response) {
+        if ($response && isset($response->SessionId)) {
             self::$_sessionId = $response->SessionId;
         }
 


### PR DESCRIPTION
Add check to prevent an error if SessionId is not in a response object.